### PR TITLE
Introduce virtual scrolling for the table on the second level

### DIFF
--- a/virtual-table-UI/src/app/app.component.ts
+++ b/virtual-table-UI/src/app/app.component.ts
@@ -15,7 +15,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
     private router: Router
   ) {
 
-  } 
+  }
   ngAfterViewChecked(): void {
     // this.router.navigate(['/third-level'], this.testDataParsed)
   }

--- a/virtual-table-UI/src/app/app.module.ts
+++ b/virtual-table-UI/src/app/app.module.ts
@@ -17,8 +17,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatSliderModule } from '@angular/material/slider';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { Ng5SliderModule } from 'ng5-slider';
-
-
+import { ScrollingModule } from '@angular/cdk/scrolling';
 
 
 @NgModule({
@@ -41,6 +40,7 @@ import { Ng5SliderModule } from 'ng5-slider';
     MatSliderModule,
     MatCheckboxModule,
     Ng5SliderModule,
+    ScrollingModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/virtual-table-UI/src/app/second-level/second-level.component.css
+++ b/virtual-table-UI/src/app/second-level/second-level.component.css
@@ -113,3 +113,8 @@
 /* .my-slider {
   transform: scale(2);
 } */
+
+.scroll-viewport {
+  height: 367px;
+  display: block;
+}

--- a/virtual-table-UI/src/app/second-level/second-level.component.html
+++ b/virtual-table-UI/src/app/second-level/second-level.component.html
@@ -193,27 +193,29 @@
                         </div> -->
                     </mat-card-header>
                 </mat-card>
-                <div *ngFor="let item of wholeData.level2.docked_compounds | keyvalue; let i = index">
+                <cdk-virtual-scroll-viewport class="scroll-viewport" itemSize="299" minBufferPx="800" maxBufferPx="1600">
+                  <div *cdkVirtualFor="let item of wholeData.level2.docked_compounds | keyvalue; let i = index">
                     <span *ngIf="!compoundBlacklist.includes(item.value.compound_identifier)">
-                        <mat-card class="compoundCard">
-                            <div class="compoundUnitFirstColumn"> <img [src]="item.value.compound_image" alt=""
-                                    (click)="clickedDockCompound(i)">
-                                {{item.value.compound_identifier}}
-                            </div>
-                            <div name="scoreBlock" style="max-width: 100px;"> {{item.value.docking_scores}}
-                            </div>
-                            <div>{{item.value.MW}}</div>
-                            <div>{{item.value.cLogP}}</div>
-                            <div>{{item.value.H_Acc}}</div>
-                            <div>{{item.value.hDonors}}</div>
-                            <div>{{item.value.tpsa}}</div>
-                            <div>{{item.value.rotable_bonds}}</div>
-                            <div class="compoundUnitLinkBlock">
-                                See More
-                            </div>
-                        </mat-card>
-                    </span>
-                </div>
+                      <mat-card class="compoundCard">
+                          <div class="compoundUnitFirstColumn"> <img [src]="item.value.compound_image" alt=""
+                                  (click)="clickedDockCompound(i)">
+                              {{item.value.compound_identifier}}
+                          </div>
+                          <div name="scoreBlock" style="max-width: 100px;"> {{item.value.docking_scores}}
+                          </div>
+                          <div>{{item.value.MW}}</div>
+                          <div>{{item.value.cLogP}}</div>
+                          <div>{{item.value.H_Acc}}</div>
+                          <div>{{item.value.hDonors}}</div>
+                          <div>{{item.value.tpsa}}</div>
+                          <div>{{item.value.rotable_bonds}}</div>
+                          <div class="compoundUnitLinkBlock">
+                              See More
+                          </div>
+                      </mat-card>
+                  </span>
+                  </div>
+                </cdk-virtual-scroll-viewport>
             </div>
         </mat-card-content>
     </mat-card>


### PR DESCRIPTION
The virtual scrolling comes directly from the Angular team in the Angular CDK. For a table with a few thousands of items, the virtual scrolling will keep the items in memory and render on the screen only the ones that are visible in the viewport.

I tested the second level with a generated file consisting of 6000 entries, and everything seemed to work well.

Let me know if there are still slowdowns when working with large collections.