### PR TITLE
Refactor the second level visualization

### DIFF
--- a/virtual-table-UI/angular.json
+++ b/virtual-table-UI/angular.json
@@ -19,7 +19,10 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "aot": true,
-            "assets": ["src/favicon.ico", "src/assets"],
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
             "styles": [
               "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
               "src/styles.css",
@@ -86,7 +89,10 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": ["src/favicon.ico", "src/assets"],
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
             "styles": [
               "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
               "src/styles.css"
@@ -102,7 +108,9 @@
               "tsconfig.spec.json",
               "e2e/tsconfig.json"
             ],
-            "exclude": ["**/node_modules/**"]
+            "exclude": [
+              "**/node_modules/**"
+            ]
           }
         },
         "e2e": {
@@ -120,5 +128,8 @@
       }
     }
   },
-  "defaultProject": "virtual-table-UI"
+  "defaultProject": "virtual-table-UI",
+  "cli": {
+    "analytics": "f5742bca-d122-4977-a5a3-283c1ada5afe"
+  }
 }

--- a/virtual-table-UI/src/app/second-level/second-level.component.html
+++ b/virtual-table-UI/src/app/second-level/second-level.component.html
@@ -32,9 +32,8 @@
                             Molecular Weight (MW):
                             <br>
                             <br>
-                            <ng5-slider [(value)]="mwMinValue" [(highValue)]="mwMaxValue" [options]="MWSliderOptions"
-                                (valueChange)="lowValueChange($event, 'MWSlider')"
-                                (highValueChange)="highValueChange($event,'MWSlider')"></ng5-slider>
+                            <ng5-slider [(value)]="filterValues.MW.min" [(highValue)]="filterValues.MW.max" [options]="MWSliderOptions"
+                                (userChangeEnd)="applyFilter()"></ng5-slider>
                             <br>
                             <span
                                 style="display: flex; flex-direction: row; justify-content: space-between; width: 600px;">
@@ -50,9 +49,8 @@
                             Partition Coefficient (SlogP):
                             <br>
                             <br>
-                            <ng5-slider [(value)]="slogpMinValue" [(highValue)]="slogpMaxValue"
-                                [options]="SlogpSliderOptions" (valueChange)="lowValueChange($event, 'SlogP')"
-                                (highValueChange)="highValueChange($event,'SlogP')"></ng5-slider>
+                            <ng5-slider [(value)]="filterValues.cLogP.min" [(highValue)]="filterValues.cLogP.max"
+                                [options]="SlogpSliderOptions" (userChangeEnd)="applyFilter()"></ng5-slider>
                             <br>
                             <br>
                         </span>
@@ -63,9 +61,8 @@
                             Topological Polar Surface Area (TPSA):
                             <br>
                             <br>
-                            <ng5-slider [(value)]="TPSAMinValue" [(highValue)]="TPSAMaxValue"
-                                [options]="TPSASliderOptions" (valueChange)="lowValueChange($event, 'tpsa')"
-                                (highValueChange)="highValueChange($event, 'tpsa')"></ng5-slider>
+                            <ng5-slider [(value)]="filterValues.tpsa.min" [(highValue)]="filterValues.tpsa.max"
+                                [options]="TPSASliderOptions" (userChangeEnd)="applyFilter()"></ng5-slider>
                             <br>
                             <span
                                 style="display: flex; flex-direction: row; justify-content: space-between; width: 600px;">
@@ -83,9 +80,8 @@
                             Hydrogen Bond Acceptors (HBA):
                             <br>
                             <br>
-                            <ng5-slider [(value)]="HBAMinValue" [(highValue)]="HBAMaxValue" [options]="HBASliderOptions"
-                                (valueChange)="lowValueChange($event, 'h-acc')"
-                                (highValueChange)="highValueChange($event, 'h-acc')"></ng5-slider>
+                            <ng5-slider [(value)]="filterValues.h_acc.min" [(highValue)]="filterValues.h_acc.max" [options]="HBASliderOptions"
+                                (userChangeEnd)="applyFilter()"></ng5-slider>
                             <br>
                             <span
                                 style="display: flex; flex-direction: row; justify-content: space-between; width: 600px;">
@@ -100,9 +96,8 @@
                             <br>
                             # H-Donors (HBD):
                             <br>
-                            <ng5-slider [(value)]="hbdMinValue" [(highValue)]="hbdMaxValue" [options]="HBDSliderOptions"
-                                (valueChange)="lowValueChange($event, 'hbd')"
-                                (highValueChange)="highValueChange($event, 'hbd')"></ng5-slider>
+                            <ng5-slider [(value)]="filterValues.h_donors.min" [(highValue)]="filterValues.h_donors.max" [options]="HBDSliderOptions"
+                                (userChangeEnd)="applyFilter()"></ng5-slider>
                             <!-- <mat-slider [value]="8" (input)="onSliderChange($event, 'hbd')" class="my-slider" min="1"
                                 max="8" step="1" value="1.5" tickInterval="1" style="width:600px">
                             </mat-slider>
@@ -121,9 +116,9 @@
                             <br>
                             Rotable Bonds (rotB):
                             <br>
-                            <ng5-slider [(value)]="rotBMinValue" [(highValue)]="rotBMaxValue"
-                                [options]="rotBSliderOptions" (valueChange)="lowValueChange($event, 'rotB')"
-                                (highValueChange)="highValueChange($event, 'rotB')"></ng5-slider>
+                            <ng5-slider [(value)]="filterValues.Rotatable_Bonds.min" [(highValue)]="filterValues.Rotatable_Bonds.max"
+                                [options]="rotBSliderOptions"
+                                (userChangeEnd)="applyFilter()"></ng5-slider>
                             <!-- <mat-slider [value]="8" (input)="onSliderChange($event, 'rotB')" class="my-slider" min="1"
                                 max="8" step="1" value="1.5" tickInterval="1" style="width:600px">
                             </mat-slider> -->
@@ -206,8 +201,7 @@
         <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="clickedRow($event)" ></tr>
     </table>
     <mat-paginator style="width: 90%;"
-      [pageSize]="initPageSize" [pageSizeOptions]="[2, 4, 6, 10, 20,100,500,1000]"
-      (page)="handlePage($event)">
+      [pageSize]="initPageSize" [pageSizeOptions]="[2, 4, 6, 10, 20,100,500,1000]">
     </mat-paginator>
     <router-outlet></router-outlet>
 </div>

--- a/virtual-table-UI/src/app/second-level/second-level.component.ts
+++ b/virtual-table-UI/src/app/second-level/second-level.component.ts
@@ -1,261 +1,176 @@
-import { Component, OnInit, ViewChild, NgZone } from '@angular/core';
-import { Location } from '@angular/common';
-import { Router, ActivatedRoute } from '@angular/router';
-// import testData from '../testData_copy.json';
+import {
+  Component,
+  OnInit,
+  ViewChild,
+  NgZone,
+  AfterViewInit,
+} from '@angular/core';
+import { Router } from '@angular/router';
 import * as NGL from '../../../node_modules/ngl';
 import { Options, LabelType, CustomStepDefinition } from 'ng5-slider';
 import { MatTable, MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 
+type ValueTypes =
+  | 'MW'
+  | 'cLogP'
+  | 'h_acc'
+  | 'h_donors'
+  | 'tpsa'
+  | 'Rotatable_Bonds';
+
 @Component({
   selector: 'app-second-level',
   templateUrl: './second-level.component.html',
-  styleUrls: ['./second-level.component.css']
+  styleUrls: ['./second-level.component.css'],
 })
-export class SecondLevelComponent implements OnInit {
+export class SecondLevelComponent implements OnInit, AfterViewInit {
   @ViewChild(MatTable) table: MatTable<any>;
   @ViewChild(MatPaginator) paginator: MatPaginator;
   @ViewChild(MatSort, { static: false }) sort: MatSort;
 
-  constructor(
-    private _location: Location,
-    private router: Router,
-    private route: ActivatedRoute,
-    private ngZone: NgZone
-    // private _bankHttpService: BankHttpService
-  ) {
-    this.fromLevel1
-      = JSON.parse(JSON.stringify(this.router.getCurrentNavigation().extras)) != undefined
-        ? JSON.parse(JSON.stringify(this.router.getCurrentNavigation().extras))
-        : this.router.getCurrentNavigation().extras
-        console.log('From level 1',this.fromLevel1 )
-  }
-  fromLevel1: any;
+  constructor(private router: Router, private ngZone: NgZone) {}
 
-  initPageSize = 10
-  ELEMENT_DATA_REAL: any = []
-  ELEMENT_DATA_REAL_decoy: any = []
+  initPageSize = 10;
 
-  removedCompounds: any = []
+  removedCompounds: any = [];
   dataSource = new MatTableDataSource();
 
+  displayedColumns: string[] = [
+    'Compound_screening_ID',
+    'docking_score',
+    'MW',
+    'cLogP',
+    'h_acc',
+    'h_donors',
+    'tpsa',
+    'Rotatable_Bonds',
+  ];
 
-  displayedColumns: string[] = ['Compound_screening_ID', 'docking_score', 'MW', 'cLogP', "h_acc", "h_donors", "tpsa", "Rotatable_Bonds"];
+  validFilterKeyNamesForCheck = new Set([
+    'MW',
+    'cLogP',
+    'h_acc',
+    'h_donors',
+    'tpsa',
+    'Rotatable_Bonds',
+  ]);
 
-  wholeData = JSON.parse(JSON.stringify(this.router.getCurrentNavigation().extras))
-  // testData: any = testData
+  compoundBlacklist = [];
 
-  //Filters
-  mwFilterHigh: any;
-  mwFilterLow: any;
+  ranges: { [key in ValueTypes]: number[] } = {
+    MW: [
+      0,
+      200,
+      250,
+      300,
+      325,
+      350,
+      375,
+      400,
+      425,
+      450,
+      500,
+      Number.MAX_SAFE_INTEGER,
+    ],
+    cLogP: [
+      Number.MIN_SAFE_INTEGER,
+      -1,
+      0,
+      1,
+      2,
+      2.5,
+      3,
+      3.5,
+      4,
+      4.5,
+      5,
+      Number.MAX_SAFE_INTEGER,
+    ],
+    tpsa: [
+      0,
+      20,
+      40,
+      60,
+      80,
+      100,
+      120,
+      140,
+      Number.MAX_SAFE_INTEGER,
+    ],
+    Rotatable_Bonds: [
+      0,
+      1,
+      3,
+      5,
+      7,
+      9,
+      10,
+      Number.MAX_SAFE_INTEGER,
+    ],
+    h_donors: [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      Number.MAX_SAFE_INTEGER,
+    ],
+    h_acc: [
+      0,
+      1,
+      3,
+      5,
+      7,
+      9,
+      10,
+      Number.MAX_SAFE_INTEGER,
+    ],
+  };
 
-  slogPFilterHigh: any;
-  slogPFilterLow: any;
+  filterValues: { [key in ValueTypes]: { min: number; max: number } } = Object.keys(this.ranges).reduce((accum, key) => {
+    accum[key] = {
+      min: this.ranges[key][0],
+      max: this.ranges[key][this.ranges[key].length - 1]
+    };
+    return accum;
+  }, {} as { [key in ValueTypes]: { min: number; max: number } });
 
-  tpsaFilterHigh: any;
-  tpsaFilterLow: any
+  MWSliderOptions = this.getSliderOptions('MW');
+  SlogpSliderOptions = this.getSliderOptions('cLogP');
+  TPSASliderOptions = this.getSliderOptions('tpsa');
+  HBASliderOptions = this.getSliderOptions('h_acc');
+  HBDSliderOptions = this.getSliderOptions('h_donors');
+  rotBSliderOptions = this.getSliderOptions('Rotatable_Bonds');
 
-  h_accFilterLow: any;
-  h_accFilterHigh: any;
+  wholeData = JSON.parse(
+    JSON.stringify(this.router.getCurrentNavigation().extras)
+  );
+  private dataArray: any = [];
 
-  hbdFilterLow: any;
-  hbdFilterHigh: any;
-
-  rotBFilterHigh: any;
-  rotBFilterLow: any;
-
-  validFilterKeyNamesForCheck = ["MW", "cLogP", "h_acc", "h_donors", "tpsa", "Rotatable_Bonds"]
-
-  compoundBlacklist = []
-
-  //MW
-  molecularWeightRanges = {
-    "0": "0",
-    "1": "200",
-    "2": "250",
-    "3": "300",
-    "4": "325",
-    "5": "350",
-    "6": "375",
-    "7": '400',
-    "8": "425",
-    "9": "450",
-    "10": "500",
-    "11": "infinity"
-  }
-
-  //This is the index of where the two slider points init in the html
-  mwMinValue: number = 0;
-  mwMaxValue: number = Object.keys(this.molecularWeightRanges).length - 1;
-
-  alphabet: string = "" + Object.keys(this.molecularWeightRanges).map(item => { return item })
-  MWSliderOptions: Options = {
-    stepsArray: this.alphabet.split(',').map((letter: string): CustomStepDefinition => {
-      return { value: Number(letter) };
-    }),
-    translate: (value: number, label: LabelType): string => {
-      return this.indexToLetter(value, this.molecularWeightRanges);
-    },
-    showTicksValues: true
-  }
-
-  indexToLetter(index: number, arrayType: any): string {
-    if (arrayType[index] == undefined) {
-      index = index - 1
-    }
-    return String(arrayType[index]);
-  }
-
-  letterToIndex(letter: string): number {
-    return this.alphabet.replace(/,/g, '').indexOf(letter);
-  }
-
-  //Slogp-----------------------
-  partitionCoefficientRanges = {
-    "0": "-infinity",
-    "1": "-1",
-    "2": "0",
-    "3": "1",
-    "4": "2",
-    "5": "2.5",
-    "6": "3",
-    "7": "3.5",
-    "8": "4",
-    "9": "4.5",
-    "10": "5",
-    "11": "infinity"
-  }
-
-  //This is the index of where the two slider points init in the html
-  slogpMinValue: number = 0;
-  slogpMaxValue: number = Object.keys(this.partitionCoefficientRanges).length - 1;
-
-  Slogpalphabet: string = "" + Object.keys(this.partitionCoefficientRanges).map(item => { return item })
-  SlogpSliderOptions: Options = {
-    stepsArray: this.Slogpalphabet.split(',').map((letter: string): CustomStepDefinition => {
-      return { value: Number(letter) };
-    }),
-    translate: (value: number, label: LabelType): string => {
-      return this.indexToLetter(value, this.partitionCoefficientRanges);
-    },
-    showTicksValues: true
-  }
-
-  //TPSA
-  topologicalPolarSurfaceArea = {
-    "0": "0",
-    "1": "20",
-    "2": "40",
-    "3": "60",
-    "4": "80",
-    "5": "100",
-    "6": "120",
-    "7": "140",
-    "8": "infinity"
-  }
-
-  //This is the index of where the two slider points init in the html
-  TPSAMinValue: number = 0;
-  TPSAMaxValue: number = Object.keys(this.topologicalPolarSurfaceArea).length - 1;
-
-  TPSAalphabet: string = "" + Object.keys(this.topologicalPolarSurfaceArea).map(item => { return item })
-  TPSASliderOptions: Options = {
-    stepsArray: this.TPSAalphabet.split(',').map((letter: string): CustomStepDefinition => {
-      return { value: Number(letter) };
-    }),
-    translate: (value: number, label: LabelType): string => {
-      return this.indexToLetter(value, this.topologicalPolarSurfaceArea);
-    },
-    showTicksValues: true
-  }
-
-  //HBA or H-Acc
-  hydrogenBondAcceptors = {
-    "0": "0",
-    "1": "1",
-    "2": "3",
-    "3": "5",
-    "4": "7",
-    "5": "9",
-    "6": "10",
-    "7": "infinity"
-  }
-
-  //This is the index of where the two slider points init in the html
-  HBAMinValue: number = 0;
-  HBAMaxValue: number = Object.keys(this.hydrogenBondAcceptors).length - 1;
-
-  HBAalphabet: string = "" + Object.keys(this.hydrogenBondAcceptors).map(item => { return item })
-  HBASliderOptions: Options = {
-    stepsArray: this.HBAalphabet.split(',').map((letter: string): CustomStepDefinition => {
-      return { value: Number(letter) };
-    }),
-    translate: (value: number, label: LabelType): string => {
-      return this.indexToLetter(value, this.hydrogenBondAcceptors);
-    },
-    showTicksValues: true
-  }
-
-  //HBD
-  hydrogenBondDonors = {
-    "0": "0",
-    "1": "1",
-    "2": "2",
-    "3": "3",
-    "4": "4",
-    "5": "5",
-    "6": "infinity"
-  }
-
-  //This is the index of where the two slider points init in the html
-  hbdMinValue: number = 0;
-  hbdMaxValue: number = Object.keys(this.hydrogenBondDonors).length - 1;
-
-  HBDalphabet: string = "" + Object.keys(this.hydrogenBondDonors).map(item => { return item })
-  HBDSliderOptions: Options = {
-    stepsArray: this.HBDalphabet.split(',').map((letter: string): CustomStepDefinition => {
-      return { value: Number(letter) };
-    }),
-    translate: (value: number, label: LabelType): string => {
-      return this.indexToLetter(value, this.hydrogenBondDonors);
-    },
-    showTicksValues: true
-  }
-
-  //RotB
-  rotableBonds = {
-    "0": "0",
-    "1": "1",
-    "2": "3",
-    "3": "5",
-    "4": "7",
-    "5": "9",
-    "6": "10",
-    "7": "infinity"
-  }
-
-  //This is the index of where the two slider points init in the html
-  rotBMinValue: number = 0;
-  rotBMaxValue: number = Object.keys(this.rotableBonds).length - 1;
-
-  rotBalphabet: string = "" + Object.keys(this.rotableBonds).map(item => { return item })
-  rotBSliderOptions: Options = {
-    stepsArray: this.rotBalphabet.split(',').map((letter: string): CustomStepDefinition => {
-      return { value: Number(letter) };
-    }),
-    translate: (value: number, label: LabelType): string => {
-      return this.indexToLetter(value, this.rotableBonds);
-    },
-    showTicksValues: true
+  private getSliderOptions(type: ValueTypes): Options {
+    return {
+      stepsArray: this.ranges[type].map(c => ({ value: c })),
+      translate(value: number) {
+        if (value === Number.MAX_SAFE_INTEGER) {
+          return 'Infinity';
+        }
+        if (value === Number.MIN_SAFE_INTEGER) {
+          return '-Infinity';
+        }
+        return value.toString();
+      },
+      showTicksValues: true,
+    };
   }
 
   ngOnInit(): void {
-    this.changeAllOptions()
-    this.populateMoleculeViewports()
-    this.initializeFilterBounds()
-    this.populateTableData()
-    this.dataSource.data = this.ELEMENT_DATA_REAL;
+    console.log(this.filterValues);
+    this.populateMoleculeViewports();
+    this.populateTableData();
+    this.dataSource.data = this.dataArray;
     this.dataSource.sort = this.sort;
   }
 
@@ -265,250 +180,93 @@ export class SecondLevelComponent implements OnInit {
 
   clickedRow(event: any) {
     // console.log('Clicked row', event.srcElement.innerText);
-    Object.keys(this.wholeData.level2.docked_compounds).forEach(key => {
-      if (this.wholeData.level2.docked_compounds[key].compound_screening_ID == event.srcElement.innerText) {
-        this.wholeData['objectOfInterest'] = this.wholeData.level2.docked_compounds[key]
-          this.router.navigate(['/third-level'],this.wholeData);
+    Object.keys(this.wholeData.level2.docked_compounds).forEach((key) => {
+      if (
+        this.wholeData.level2.docked_compounds[key].compound_screening_ID ==
+        event.srcElement.innerText
+      ) {
+        this.wholeData.objectOfInterest = this.wholeData.level2.docked_compounds[
+          key
+        ];
+        this.router.navigate(['/third-level'], this.wholeData);
       }
-    })
+    });
   }
-
-
   sortData(event: any) {
     // console.log('Sorting for:', event)
   }
 
   populateTableData() {
-    Object.keys(this.wholeData.level2.docked_compounds).forEach(element => {
-      var subSet = this.getSubsetOfObject(this.wholeData.level2.docked_compounds[element])
-      this.ELEMENT_DATA_REAL.push(subSet)
-      this.ELEMENT_DATA_REAL_decoy.push(subSet)
-    })
-    this.dataSource.data = this.ELEMENT_DATA_REAL
+    Object.keys(this.wholeData.level2.docked_compounds).forEach((element) => {
+      const subSet = this.getSubsetOfObject(
+        this.wholeData.level2.docked_compounds[element]
+      );
+      this.dataArray.push(subSet);
+    });
+    this.dataSource.data = this.dataArray;
   }
 
   getSubsetOfObject(objectInput) {
-    let { compound_screening_ID, Top_Scores, MW, cLogP, h_acc, h_donors, tpsa, Rotatable_Bonds, docking_score, ...partialObject } = objectInput;
-    let subset = { compound_screening_ID, Top_Scores, MW, cLogP, h_acc, h_donors, tpsa, Rotatable_Bonds, docking_score };
-    return subset
+    const {
+      compound_screening_ID,
+      Top_Scores,
+      MW,
+      cLogP,
+      h_acc,
+      h_donors,
+      tpsa,
+      Rotatable_Bonds,
+      docking_score,
+    } = objectInput;
+    const subset = {
+      compound_screening_ID,
+      Top_Scores,
+      MW,
+      cLogP,
+      h_acc,
+      h_donors,
+      tpsa,
+      Rotatable_Bonds,
+      docking_score,
+    };
+    return subset;
   }
 
   backClicked() {
     this.router.navigate(['/first-level'], this.wholeData);
   }
 
-  // clickedDockCompound(index: any) {
-  //   console.log('clicked docked compund')
-  //   this.router.navigate(['/third-level'], this.wholeData);
-  // }
-
   populateMoleculeViewports() {
     this.ngZone.runOutsideAngular(() => {
       setTimeout(() => {
-        var stage = new NGL.Stage("secondLevelviewport" + '1');
-        stage.setParameters({ backgroundColor: "white", hoverTimeout: -1 });
-        window.addEventListener("resize", function (event) {
-          stage.handleResize();
-        }, true);
-        stage.loadFile("rcsb://1crn", { defaultRepresentation: true });
+        const stage = new NGL.Stage('secondLevelviewport' + '1');
+        stage.setParameters({ backgroundColor: 'white', hoverTimeout: -1 });
+        window.addEventListener(
+          'resize',
+          () => {
+            stage.handleResize();
+          },
+          true
+        );
+        stage.loadFile('rcsb://1crn', { defaultRepresentation: true });
       }, 1);
     });
   }
 
-  asIsOrder(a, b) {
-    return 1;
-  }
-
-  validateCompounds() {
-    var compoundValid = true;
-    Object.keys(this.wholeData.level2.docked_compounds).forEach(item => {
-      compoundValid = true;
-      var compoundUnderReview = this.wholeData.level2.docked_compounds[item]
-      Object.keys(compoundUnderReview).forEach(compoundDetail => {
-        if (this.validFilterKeyNamesForCheck.includes(compoundDetail)) {
-          //Checking filter value here
-          console.log('compoundUnderReview[compoundDetail]:',compoundDetail)
-          if (compoundDetail == 'MW') {
-            if (!(this.between(compoundUnderReview[compoundDetail], this.mwFilterLow, this.mwFilterHigh))) {
-              compoundValid = false;
-            }
-          }
-          if (compoundDetail == 'cLogP') {
-            if (!(this.between(compoundUnderReview[compoundDetail], this.slogPFilterLow, this.slogPFilterHigh))) {
-              compoundValid = false;
-            }
-          }
-          if (compoundDetail == 'h_acc') {
-            if (!(this.between(compoundUnderReview[compoundDetail], this.h_accFilterLow, this.h_accFilterHigh))) {
-              compoundValid = false;
-            }
-          }
-          if (compoundDetail == 'h_donors') {
-            if (!(this.between(compoundUnderReview[compoundDetail], this.hbdFilterLow, this.hbdFilterHigh))) {
-              compoundValid = false;
-            }
-          }
-          if (compoundDetail == 'tpsa') {
-            if (!(this.between(compoundUnderReview[compoundDetail], this.tpsaFilterLow, this.tpsaFilterHigh))) {
-              compoundValid = false;
-            }
-          }
-          if (compoundDetail == 'Rotatable_Bonds') {
-            if (!(this.between(compoundUnderReview[compoundDetail], this.rotBFilterLow, this.rotBFilterHigh))) {
-              compoundValid = false;
-            }
-          }
+  applyFilter() {
+    const keys = Object.keys(this.filterValues);
+    this.dataSource.data = this.dataArray.filter(value => {
+      for (const key of keys) {
+        if (value[key] === undefined) {
+          return true;
         }
-      })
-      if (!compoundValid) {
-        //Mark Invalid
-        this.compoundBlacklist.indexOf(compoundUnderReview.Compound_screening_ID) === -1 ? this.compoundBlacklist.push(compoundUnderReview.Compound_screening_ID) : null;
-      } else {
-        //Mark Valid
-        this.compoundBlacklist = this.compoundBlacklist.filter(item => { return item != compoundUnderReview.Compound_screening_ID })
+        const numeric = parseInt(value[key], 10);
+        const bounds = this.filterValues[key];
+        if (numeric < bounds.min || numeric > bounds.max) {
+          return false;
+        }
       }
-    })
-
-    console.log('Blacklst', this.compoundBlacklist)
-  }
-
-  updateTableDataFromBlackList(compoundUnderReview) {
-    this.ELEMENT_DATA_REAL = this.ELEMENT_DATA_REAL_decoy
-    Object.keys(this.ELEMENT_DATA_REAL).forEach(element => {
-      if (this.compoundBlacklist.includes(this.ELEMENT_DATA_REAL[element].CompoudBaseID)) {
-        delete this.ELEMENT_DATA_REAL[element]
-      }
+      return true;
     });
   }
-
-  lowValueChange(value: any, label: any) {
-    if (label == 'MWSlider') {
-      this.mwFilterLow = this.convertToInfinityOrNot(this.molecularWeightRanges[value]);
-    }
-    if (label == 'SlogP') {
-      this.slogPFilterLow = this.convertToInfinityOrNot(this.partitionCoefficientRanges[value])
-    }
-    if (label == 'tpsa') {
-      this.tpsaFilterLow = this.convertToInfinityOrNot(this.topologicalPolarSurfaceArea[value])
-    }
-    if (label == 'h-acc') {
-      this.h_accFilterLow = this.convertToInfinityOrNot(this.hydrogenBondAcceptors[value])
-    }
-    if (label == 'hbd') {
-      this.hbdFilterLow = this.convertToInfinityOrNot(this.hydrogenBondDonors[value])
-    }
-    if (label == 'rotB') {
-      this.rotBFilterLow = this.convertToInfinityOrNot(this.rotableBonds[value])
-    }
-    this.validateCompounds()
-  }
-
-  highValueChange(value: any, label: any) {
-    if (label == 'MWSlider') {
-      this.mwFilterHigh = this.convertToInfinityOrNot(this.molecularWeightRanges[value])
-    }
-    if (label == 'SlogP') {
-      this.slogPFilterHigh = this.convertToInfinityOrNot(this.partitionCoefficientRanges[value])
-    }
-    if (label == 'tpsa') {
-      this.tpsaFilterHigh = this.convertToInfinityOrNot(this.topologicalPolarSurfaceArea[value])
-    }
-    if (label == 'h-acc') {
-      this.h_accFilterHigh = this.convertToInfinityOrNot(this.hydrogenBondAcceptors[value])
-    }
-    if (label == 'hbd') {
-      this.hbdFilterHigh = this.convertToInfinityOrNot(this.hydrogenBondDonors[value])
-    }
-    if (label == 'rotB') {
-      this.rotBFilterHigh = this.convertToInfinityOrNot(this.rotableBonds[value])
-    }
-    // var t0 = performance.now()
-    this.validateCompounds()
-    // var t1 = performance.now()
-    // console.log("Call to validateCompounds took " + (t1 - t0) + " milliseconds.")
-  }
-
-  changeOptionsForMw() {
-    const newOptions: Options = Object.assign({}, this.MWSliderOptions);
-    this.MWSliderOptions = newOptions;
-  }
-
-  changeOptionsForSlogP() {
-    const newOptions: Options = Object.assign({}, this.SlogpSliderOptions);
-    this.SlogpSliderOptions = newOptions;
-  }
-
-  changeOptionsForTPSA() {
-    const newOptions: Options = Object.assign({}, this.TPSASliderOptions);
-    this.TPSASliderOptions = newOptions;
-  }
-
-  changeOptionsForHBA() {
-    const newOptions: Options = Object.assign({}, this.HBASliderOptions);
-    this.HBASliderOptions = newOptions;
-  }
-
-  changeOptionsForHBD() {
-    const newOptions: Options = Object.assign({}, this.HBDSliderOptions);
-    this.HBDSliderOptions = newOptions;
-  }
-
-  changeOptionsForRotB() {
-    const newOptions: Options = Object.assign({}, this.rotBSliderOptions);
-    this.rotBSliderOptions = newOptions;
-  }
-
-  changeAllOptions() {
-    this.changeOptionsForMw()
-    this.changeOptionsForSlogP()
-    this.changeOptionsForHBA()
-    this.changeOptionsForHBD()
-    this.changeOptionsForTPSA()
-    this.changeOptionsForRotB()
-  }
-
-  convertOjectToArray(object: any) {
-    var someArray = []
-    Object.keys(object).forEach((item) => {
-      someArray.push(String(object[item]))
-    })
-    return someArray;
-  }
-  convertToInfinityOrNot(item: any) {
-    if (item == 'infinity') {
-      return Number.POSITIVE_INFINITY
-    }
-    else if (item == '-infinity') {
-      return Number.NEGATIVE_INFINITY
-    } else {
-      return item;
-    }
-  }
-  between(x, min, max) {
-    return x >= min && x <= max;
-  }
-  initializeFilterBounds() {
-    this.mwFilterHigh = this.convertToInfinityOrNot(this.molecularWeightRanges[Object.keys(this.molecularWeightRanges).length - 1])//this.molecularWeightRanges[Object.keys(this.molecularWeightRanges).length - 1]
-    this.mwFilterLow = this.convertToInfinityOrNot(this.molecularWeightRanges[0])
-
-    this.slogPFilterHigh = this.convertToInfinityOrNot(this.partitionCoefficientRanges[Object.keys(this.partitionCoefficientRanges).length - 1])
-    this.slogPFilterLow = this.convertToInfinityOrNot(this.partitionCoefficientRanges[0])
-
-    this.tpsaFilterHigh = this.convertToInfinityOrNot(this.topologicalPolarSurfaceArea[Object.keys(this.topologicalPolarSurfaceArea).length - 1])
-    this.tpsaFilterLow = this.convertToInfinityOrNot(this.topologicalPolarSurfaceArea[0])
-
-    this.h_accFilterHigh = this.convertToInfinityOrNot(this.hydrogenBondAcceptors[Object.keys(this.hydrogenBondAcceptors).length - 1])
-    this.h_accFilterLow = this.convertToInfinityOrNot(this.hydrogenBondAcceptors[0])
-
-    this.hbdFilterHigh = this.convertToInfinityOrNot(this.hydrogenBondDonors[Object.keys(this.hydrogenBondDonors).length - 1])
-    this.hbdFilterLow = this.convertToInfinityOrNot(this.hydrogenBondDonors[0])
-
-    this.rotBFilterHigh = this.convertToInfinityOrNot(this.rotableBonds[Object.keys(this.rotableBonds).length - 1])
-    this.rotBFilterLow = this.convertToInfinityOrNot(this.rotableBonds[0])
-  }
-
-  handlePage(input: any) {
-  }
-
-
 }


### PR DESCRIPTION
The filtering is now visibly faster with lower Big-O complexity.

This PR also drops part of the original source code after some refactoring. There are few main types of changes:
- Extracted filter field definitions to an object. This removes some duplication.
- Simplified label/value conversion in the slider & extracted the options definition in a function.
- The slider component has an output `userChangeEnd` which we can use instead of handling the two outputs used for two-way data-binding.
- Simplified filtering. Instead of collecting an ignore list, now the filtering goes via a single pass.
- More type definitions for stronger typings.

If I've missed anything from the original semantics (especially in the filtering), please feel free to use this PR as a base and build on top. I can do another pass if there are new heavy operations needed.

*I haven't tested the code well. Please do a thorough regression testing before deployment*.